### PR TITLE
Added resource node highlighting to GhostBuilding

### DIFF
--- a/TowerDefence/Assets/Prefabs/ResourceNodes/pfGold.prefab
+++ b/TowerDefence/Assets/Prefabs/ResourceNodes/pfGold.prefab
@@ -100,6 +100,7 @@ GameObject:
   - component: {fileID: 108625052455787070}
   - component: {fileID: 4821986759409740679}
   - component: {fileID: 7818619001647063818}
+  - component: {fileID: 1346388576729580681}
   m_Layer: 0
   m_Name: Sprite
   m_TagString: Untagged
@@ -189,3 +190,16 @@ MonoBehaviour:
   _spriteList: {fileID: 11400000, guid: 59ed6976037d5e948af5ea5753406fe5, type: 2}
   _colorList: {fileID: 11400000, guid: 74b3bfea2442cee4db8f13502232c496, type: 2}
   _seed: {fileID: 11400000, guid: dda94388aa7949b4f9d9d028eceb481a, type: 2}
+--- !u!114 &1346388576729580681
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7915595883110976184}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dda33ec8430d52e46b99e5131605bc7e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _resourceNode: {fileID: 1421131883208819245}

--- a/TowerDefence/Assets/Prefabs/ResourceNodes/pfStone.prefab
+++ b/TowerDefence/Assets/Prefabs/ResourceNodes/pfStone.prefab
@@ -100,6 +100,7 @@ GameObject:
   - component: {fileID: 5512348127977163961}
   - component: {fileID: 5512348127977163960}
   - component: {fileID: 5512348127977163966}
+  - component: {fileID: 4723642555942335804}
   m_Layer: 0
   m_Name: Sprite
   m_TagString: Untagged
@@ -189,3 +190,16 @@ MonoBehaviour:
   _spriteList: {fileID: 11400000, guid: 105a67703e91141449e3392693e8100e, type: 2}
   _colorList: {fileID: 11400000, guid: b9b5c36376dd5b54ab4d1579857f0b1c, type: 2}
   _seed: {fileID: 11400000, guid: dda94388aa7949b4f9d9d028eceb481a, type: 2}
+--- !u!114 &4723642555942335804
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5512348127977163963}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dda33ec8430d52e46b99e5131605bc7e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _resourceNode: {fileID: 3134471631360587201}

--- a/TowerDefence/Assets/Prefabs/ResourceNodes/pfTree.prefab
+++ b/TowerDefence/Assets/Prefabs/ResourceNodes/pfTree.prefab
@@ -11,6 +11,7 @@ GameObject:
   - component: {fileID: 6954216153477172718}
   - component: {fileID: 6954216153477172719}
   - component: {fileID: 6954216153477172713}
+  - component: {fileID: 2866580111037395377}
   m_Layer: 0
   m_Name: Trunk
   m_TagString: Untagged
@@ -100,6 +101,19 @@ MonoBehaviour:
   _spriteList: {fileID: 11400000, guid: d3bc82c843c6c8c4aa7988ac1c4b746e, type: 2}
   _colorList: {fileID: 11400000, guid: e379627dcf67e3f4bb57ab88027c31de, type: 2}
   _seed: {fileID: 11400000, guid: dda94388aa7949b4f9d9d028eceb481a, type: 2}
+--- !u!114 &2866580111037395377
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6954216153477172716}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dda33ec8430d52e46b99e5131605bc7e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _resourceNode: {fileID: 541131806261212310}
 --- !u!1 &6954216153523928856
 GameObject:
   m_ObjectHideFlags: 0
@@ -111,6 +125,7 @@ GameObject:
   - component: {fileID: 6954216153523928858}
   - component: {fileID: 6954216153523928859}
   - component: {fileID: 6954216153523928853}
+  - component: {fileID: 4160161618442831844}
   m_Layer: 0
   m_Name: Leaves
   m_TagString: Untagged
@@ -200,6 +215,19 @@ MonoBehaviour:
   _spriteList: {fileID: 11400000, guid: 83df109660170a6409e79ab06d452593, type: 2}
   _colorList: {fileID: 11400000, guid: 4d80f6ec1ef3a414da9df62bf1214d73, type: 2}
   _seed: {fileID: 11400000, guid: dda94388aa7949b4f9d9d028eceb481a, type: 2}
+--- !u!114 &4160161618442831844
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6954216153523928856}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dda33ec8430d52e46b99e5131605bc7e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _resourceNode: {fileID: 541131806261212310}
 --- !u!1 &6954216153753006155
 GameObject:
   m_ObjectHideFlags: 0

--- a/TowerDefence/Assets/ScObs/ColorValues/ResourceNodeHighlightColor.asset
+++ b/TowerDefence/Assets/ScObs/ColorValues/ResourceNodeHighlightColor.asset
@@ -9,8 +9,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8ee1a0999f51d2946afa77f469fa4769, type: 3}
-  m_Name: GoldSprites
+  m_Script: {fileID: 11500000, guid: 40c055ec9e6832848b144b61c0cfd548, type: 3}
+  m_Name: ResourceNodeHighlightColor
   m_EditorClassIdentifier: 
-  _items:
-  - {fileID: 21300000, guid: dc3693b410be8114892df4310d01e05e, type: 3}
+  _value: {r: 0, g: 1, b: 0.33486915, a: 1}

--- a/TowerDefence/Assets/ScObs/ColorValues/ResourceNodeHighlightColor.asset.meta
+++ b/TowerDefence/Assets/ScObs/ColorValues/ResourceNodeHighlightColor.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: dcb23ceeb58927c4bb86b086ae808c0f
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TowerDefence/Assets/Scenes/GameplayScene.unity
+++ b/TowerDefence/Assets/Scenes/GameplayScene.unity
@@ -865,6 +865,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _buildingTypes: {fileID: 11400000, guid: 0eedc7399b3d24d4b80685a19d8e02a0, type: 2}
   _buildingPlacer: {fileID: 972399360}
+  _resourceNodeHighlightColor: {fileID: 11400000, guid: dcb23ceeb58927c4bb86b086ae808c0f, type: 2}
+  _allColliders: []
 --- !u!4 &385935929
 Transform:
   m_ObjectHideFlags: 0
@@ -1916,7 +1918,7 @@ MonoBehaviour:
     ModeOverride: 0
     LensShift: {x: 0, y: 0}
     GateFit: 2
-    m_SensorSize: {x: 1.7768762, y: 1}
+    m_SensorSize: {x: 1.7759336, y: 1}
   m_Transitions:
     m_BlendHint: 0
     m_InheritPosition: 0

--- a/TowerDefence/Assets/Scripts/MoBes/GhostBuilding.cs
+++ b/TowerDefence/Assets/Scripts/MoBes/GhostBuilding.cs
@@ -1,9 +1,10 @@
 using nsBuildingPlacer;
 using nsBuildingType;
 using nsBuildingTypes;
+using nsColorValue;
 using nsMousePositionHelper;
-using nsNearbyResourceNodeFinder;
 using nsResourceGenerator;
+using nsResourceNode;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -13,17 +14,13 @@ namespace nsGhostBuilding
     {
         [SerializeField] private BuildingTypes _buildingTypes;
         [SerializeField] private BuildingPlacer _buildingPlacer;
+        [SerializeField] private ColorValue _resourceNodeHighlightColor;
 
         private Dictionary<BuildingType, ResourceGenerator> _resourceGeneratorGhosts;
-
-        private NearbyResourceNodeFinder _nearbyResourceNodeFinder;
-        private MousePositionHelper _mousePositionHelper;
-
-        private BuildingType _currentBuildingType;
         private ResourceGenerator _currentResourceGeneratorGhost;
-
-        private int _nearbyResourceNodeCount;
-        private int _totalAmountPerCycle;
+        private BuildingType _currentBuildingType;
+        private MousePositionHelper _mousePositionHelper;
+        private HashSet<ResourceNode> _currentlyHighlightedResourceNodes;
 
         private void OnEnable()
         {
@@ -38,7 +35,14 @@ namespace nsGhostBuilding
         private void BuildingPlacer_OnCurrentBuildingTypeChange(BuildingType buildingType)
         {
             _currentBuildingType = buildingType;
-            if (_currentResourceGeneratorGhost != null) _currentResourceGeneratorGhost.gameObject.SetActive(false);
+            if (_currentResourceGeneratorGhost != null)
+            {
+                foreach (ResourceNode resourceNode in _currentlyHighlightedResourceNodes)
+                {
+                    resourceNode.ChangeColor(null);
+                }
+                _currentResourceGeneratorGhost.gameObject.SetActive(false);
+            }
             if (_currentBuildingType != null)
             {
                 if (_mousePositionHelper != null) transform.position = _mousePositionHelper.MouseWorldPosition;
@@ -50,7 +54,7 @@ namespace nsGhostBuilding
         private void Awake()
         {
             _resourceGeneratorGhosts = new Dictionary<BuildingType, ResourceGenerator>();
-            _nearbyResourceNodeFinder = new NearbyResourceNodeFinder();
+            _currentlyHighlightedResourceNodes = new HashSet<ResourceNode>();
             _mousePositionHelper = null;
             _currentBuildingType = null;
 
@@ -74,9 +78,20 @@ namespace nsGhostBuilding
             if (_currentBuildingType == null) return;
 
             transform.position = _mousePositionHelper.MouseWorldPosition;
-            _nearbyResourceNodeCount = _nearbyResourceNodeFinder.OverlapCircleAll(transform.position, _currentBuildingType.ResourceGeneratorData.NodeDetectionRadius, _currentBuildingType.ResourceGeneratorData.ResourceType);
-            _totalAmountPerCycle = _nearbyResourceNodeCount * _currentBuildingType.ResourceGeneratorData.AmountPerCycle;
-            _currentResourceGeneratorGhost.OnOverlapCircleAll?.Invoke(_nearbyResourceNodeCount, _totalAmountPerCycle);
+
+            HashSet<ResourceNode> desiredNearbyResourceNodes = _currentResourceGeneratorGhost.FindNearbyResourceNodes();
+            foreach (ResourceNode resourceNode in desiredNearbyResourceNodes)
+            {
+                resourceNode.ChangeColor(_resourceNodeHighlightColor);
+            }
+
+            _currentlyHighlightedResourceNodes.ExceptWith(desiredNearbyResourceNodes);
+            foreach (ResourceNode resourceNode in _currentlyHighlightedResourceNodes)
+            {
+                resourceNode.ChangeColor(null);
+            }
+
+            _currentlyHighlightedResourceNodes = desiredNearbyResourceNodes;
         }
     }
 }

--- a/TowerDefence/Assets/Scripts/MoBes/ResourceGenerator.cs
+++ b/TowerDefence/Assets/Scripts/MoBes/ResourceGenerator.cs
@@ -1,8 +1,10 @@
 using nsBuildingType;
 using nsNearbyResourceNodeFinder;
 using nsResourceGeneratorData;
+using nsResourceNode;
 using nsResourceStorage;
 using System;
+using System.Collections.Generic;
 using UnityEngine;
 
 namespace nsResourceGenerator
@@ -42,9 +44,7 @@ namespace nsResourceGenerator
 
         private void Start()
         {
-            _nearbyResourceNodeCount = _nearbyResourceNodeFinder.OverlapCircleAll(transform.position, _resourceGeneratorData.NodeDetectionRadius, _resourceGeneratorData.ResourceType);
-            _totalAmountPerCycle = _nearbyResourceNodeCount * _resourceGeneratorData.AmountPerCycle;
-            OnOverlapCircleAll?.Invoke(_nearbyResourceNodeCount, _totalAmountPerCycle);
+            FindNearbyResourceNodes();
         }
 
         private void Update()
@@ -57,6 +57,15 @@ namespace nsResourceGenerator
                 _timeLeft += _timeCost;
                 _resourceStorage.AddResource(_resourceGeneratorData.ResourceType, _totalAmountPerCycle);
             }
+        }
+
+        public HashSet<ResourceNode> FindNearbyResourceNodes()
+        {
+            HashSet<ResourceNode> desiredNearbyResourceNodes = _nearbyResourceNodeFinder.OverlapCircleAll(transform.position, _resourceGeneratorData.NodeDetectionRadius, _resourceGeneratorData.ResourceType);
+            _nearbyResourceNodeCount = desiredNearbyResourceNodes.Count;
+            _totalAmountPerCycle = _nearbyResourceNodeCount * _resourceGeneratorData.AmountPerCycle;
+            OnOverlapCircleAll?.Invoke(_nearbyResourceNodeCount, _totalAmountPerCycle);
+            return desiredNearbyResourceNodes;
         }
 
         public void SetTransparent(bool value)

--- a/TowerDefence/Assets/Scripts/MoBes/ResourceNode.cs
+++ b/TowerDefence/Assets/Scripts/MoBes/ResourceNode.cs
@@ -1,4 +1,6 @@
+using nsColorValue;
 using nsResourceType;
+using System;
 using UnityEngine;
 
 namespace nsResourceNode
@@ -8,5 +10,12 @@ namespace nsResourceNode
         [SerializeField] private ResourceType _resourceType;
 
         public ResourceType ResourceType => _resourceType;
+
+        public Action<ColorValue> OnColorChange;
+
+        public void ChangeColor(ColorValue colorValue)
+        {
+            OnColorChange?.Invoke(colorValue);
+        }
     }
 }

--- a/TowerDefence/Assets/Scripts/MoBes/ResourceNodeColorChanger.cs
+++ b/TowerDefence/Assets/Scripts/MoBes/ResourceNodeColorChanger.cs
@@ -1,0 +1,50 @@
+using nsColorValue;
+using nsResourceNode;
+using UnityEngine;
+
+namespace nsResourceNodeColorChanger
+{
+    public class ResourceNodeColorChanger : MonoBehaviour
+    {
+        [SerializeField] private ResourceNode _resourceNode;
+
+        private SpriteRenderer _spriteRenderer;
+        private Color _defaultColor;
+        private bool _isColorCached;
+
+        private void OnEnable()
+        {
+            _resourceNode.OnColorChange += ResourceNode_OnColorChange;
+        }
+
+        private void OnDisable()
+        {
+            _resourceNode.OnColorChange -= ResourceNode_OnColorChange;
+        }
+
+        private void ResourceNode_OnColorChange(ColorValue colorValue)
+        {
+            if (colorValue != null)
+            {
+                if (_isColorCached == false)
+                {
+                    _defaultColor = _spriteRenderer.color;
+                    _isColorCached = true;
+                }
+                _spriteRenderer.color = colorValue.Value;
+            }
+            if ((colorValue == null) && _isColorCached)
+            {
+                _spriteRenderer.color = _defaultColor;
+            }
+        }
+
+        private void Awake()
+        {
+            //Can't cache the color on Awake because it may be randomized in a different component's Awake
+            _spriteRenderer = GetComponent<SpriteRenderer>();
+            _defaultColor = Color.white;
+            _isColorCached = false;
+        }
+    }
+}

--- a/TowerDefence/Assets/Scripts/MoBes/ResourceNodeColorChanger.cs.meta
+++ b/TowerDefence/Assets/Scripts/MoBes/ResourceNodeColorChanger.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: dda33ec8430d52e46b99e5131605bc7e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TowerDefence/Assets/Scripts/Other/NearbyResourceNodeFinder.cs
+++ b/TowerDefence/Assets/Scripts/Other/NearbyResourceNodeFinder.cs
@@ -1,24 +1,25 @@
 using nsResourceNode;
 using nsResourceType;
+using System.Collections.Generic;
 using UnityEngine;
 
 namespace nsNearbyResourceNodeFinder
 {
     public class NearbyResourceNodeFinder
     {
-        public int OverlapCircleAll(Vector2 point, float radius, ResourceType resourceType)
+        public HashSet<ResourceNode> OverlapCircleAll(Vector2 point, float radius, ResourceType resourceType)
         {
-            int nearbyResourceNodeCount = 0;
-            Collider2D[] nearbyColliders = Physics2D.OverlapCircleAll(point, radius);
-            foreach (Collider2D nearbyCollider in nearbyColliders)
+            var desiredNearbyResourceNodes = new HashSet<ResourceNode>();
+            Collider2D[] allNearbyColliders = Physics2D.OverlapCircleAll(point, radius);
+            foreach (Collider2D nearbyCollider in allNearbyColliders)
             {
                 ResourceNode resourceNode = nearbyCollider.GetComponent<ResourceNode>();
                 if (resourceNode != null)
                 {
-                    if (resourceNode.ResourceType == resourceType) nearbyResourceNodeCount++;
+                    if (resourceNode.ResourceType == resourceType) desiredNearbyResourceNodes.Add(resourceNode);
                 }
             }
-            return nearbyResourceNodeCount;
+            return desiredNearbyResourceNodes;
         }
     }
 }

--- a/TowerDefence/Assets/StreamingAssets.meta
+++ b/TowerDefence/Assets/StreamingAssets.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d08498bc14b9a9446b0808731f2cbd91
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
MoBes:

- Added ResourceNodeColorChanger to respond to the even in ResourceNode.
- Changed GhostBuilding to highlight the resource nodes within the detection radius.
- Changed ResourceGenerator to return the nearby resource nodes for GhostBuilding.
- Changed ResourceNode to fire an event when it needs to change color.
- Changed NearbyResourceNodeFinder to return a hashset of ResourceNodes.