### PR TITLE
Bugfix for GhostBuilding getting stuck near enemies

### DIFF
--- a/TowerDefence/Assets/Scripts/MoBes/GhostBuilding.cs
+++ b/TowerDefence/Assets/Scripts/MoBes/GhostBuilding.cs
@@ -151,7 +151,7 @@ namespace nsGhostBuilding
             }
             foreach (Colorable colorable in _cachedColorables)
             {
-                colorable.ChangeColor(null);
+                if (colorable != null) colorable.ChangeColor(null);
             }
             _cachedColorables = _resourceNodes;
             _cachedColorables.UnionWith(_colorableColliders);


### PR DESCRIPTION
MoBes:

- Changed GhostBuilding to do a null check when resetting color to previously colored objects in case they've been destroyed.